### PR TITLE
Use Django SESSION_COOKIE_NAME setting instead of sessionid

### DIFF
--- a/swampdragon_auth/socketconnection.py
+++ b/swampdragon_auth/socketconnection.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth import login, get_user_model
 from django.contrib.sessions.models import Session
 from swampdragon.connections.sockjs_connection import DjangoSubscriberConnection
@@ -12,7 +13,8 @@ class HttpDataConnection(DjangoSubscriberConnection):
         try:
             if self._user is not None:
                 return self._user
-            morsel = self.session.conn_info.cookies.get('sessionid')
+            cookie_name = getattr(settings, 'SESSION_COOKIE_NAME', 'sessionid')
+            morsel = self.session.conn_info.cookies.get(cookie_name)
             session = Session.objects.get(session_key=morsel.value)
             decoded_session = session.get_decoded()
             self._user = get_user_model().objects.get(pk=decoded_session['_auth_user_id'])


### PR DESCRIPTION
Replace hardcoded 'sessionid' cookie name with actual Django setting.
