### PR TITLE
Added token authentication

### DIFF
--- a/swampdragon_auth/mixins.py
+++ b/swampdragon_auth/mixins.py
@@ -1,0 +1,7 @@
+
+class TokenAuthMixin(object):
+    def handle(self,data):
+        if data['verb'] == 'subscribe' and 'auth' in data['args']:
+            auth_token = data['args'].pop('auth')
+            self.connection.authenticate(auth_token)
+        super(TokenAuthMixin, self).handle(data)

--- a/swampdragon_auth/socketconnection.py
+++ b/swampdragon_auth/socketconnection.py
@@ -5,11 +5,13 @@ from swampdragon.connections.sockjs_connection import DjangoSubscriberConnection
 
 
 class _RequestWrapper(object):
+
     def __init__(self, session):
         self.session = session
 
 
 class HttpDataConnection(DjangoSubscriberConnection):
+
     def __init__(self, session):
         self._user = None
 
@@ -34,3 +36,29 @@ class HttpDataConnection(DjangoSubscriberConnection):
     @property
     def user(self):
         return self.get_user()
+
+
+class RemoteDataConnection(DjangoSubscriberConnection):
+
+    def __init__(self, session):
+        self._user = None
+        try:
+            from rest_framework.authtoken.models import Token
+        except ImportError:
+            raise ImportError(
+                "Django Rest Framework is required")
+        super(RemoteDataConnection, self).__init__(session)
+
+    def get_user(self):
+        return self._user
+
+    @property
+    def user(self):
+        return self.get_user()
+
+    def authenticate(self, token):
+        try:
+            t = Token.objects.get(key=token)
+            self._user = t.user
+        except Token.DoesNotExist:
+            self._user = None


### PR DESCRIPTION
Added Django Rest Framework token authentication.

I am not sure where to add the  usage info in read me.The mixin is to be used as follows:




1.Add the following to the settings file:
```python
SWAMP_DRAGON_CONNECTION = ('swampdragon_tokenauth.socketconnection.RemoteDataConnection', '/data')
```


2.Add the `TokenAuthMixin` to your router:

```python

from swampdragon_tokenauth.mixins import TokenAuthMixin
from swampdragon.route_handler import ModelRouter

# TokenAuthMixin should come before the model router

class TodoItemRouter(TokenAuthMixin,ModelRouter):
    route_name = 'todo-item'
    serializer_class = TodoItemSerializer
    model = TodoItem
    permission_classes = [LoginRequired()]

    def get_object(self, **kwargs):
        return self.model.objects.get(pk=kwargs['id'])

    def get_query_set(self, **kwargs):
        return self.model.objects.filter(todo_list__id=kwargs['list_id'])
```        

Pass in the drf auth token as 'auth' argument  when subscribing to a channel:

In angularjs:

```javascript
    $dragon.onReady(function() {
        $dragon.subscribe('todo-item', $scope.channel, {auth:"your_auth_token"}).then(function(response) {
            // code
        });
        })
```