### PR TITLE
Fix broken layout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ or
 
 1.  Add the following to the settings file:
 
-`SWAMP_DRAGON_CONNECTION = ('swampdragon_tokenauth.socketconnection.RemoteDataConnection', '/data')`
+`SWAMP_DRAGON_CONNECTION = ('swampdragon.socketconnection.RemoteDataConnection', '/data')`
 
 2.  Add the TokenAuthMixin to your router:
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ or
 
 2.  Add the TokenAuthMixin to your router:
 
+```
 from swampdragon_tokenauth.mixins import TokenAuthMixin
 from swampdragon.route_handler import ModelRouter
+```
 
 ### TokenAuthMixin should come before the model router
 


### PR DESCRIPTION
This makes the import lines appear as
```
code block
```